### PR TITLE
Fix: restore nginx-served shared media for plots

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -1,0 +1,26 @@
+name: Smoke Test (Media via Nginx)
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start services
+        run: docker compose -f docker-compose.ci.yml up -d --build --wait
+
+      - name: Run smoke test
+        run: ./tests/smoke_test_media.sh
+
+      - name: Show logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.ci.yml logs
+
+      - name: Teardown
+        if: always()
+        run: docker compose -f docker-compose.ci.yml down -v

--- a/Bayesian_Modeling.py
+++ b/Bayesian_Modeling.py
@@ -114,7 +114,7 @@ def likelihood_KDE(X_train,X_test, y_train, y_test,x_cur, best_parameters):
     # # n_out = plt.hist([X_test[y_test>0],X_test[y_test==0]], color=['r','g'],histtype='barstacked',rwidth=(X_test.max() - X_test.min()) / kde_pos.bandwidth)
     # #.iloc[:,feat4]
     # n_out = axes[1].hist([X_test[y_test>0],X_test[y_test==0]], color=['g','r'],histtype='barstacked',rwidth=(X_test.max() - X_test.min()) / kde_pos.bandwidth)
-    st.pyplot(fig2)
+    shared_pyplot(fig2)
     #st.write('WIDTH of BARS: rwidth=(X_test.max() - X_test.min())',rwidth=(X_test.max() - X_test.min()))    
     #st.write('xlim', ax1.get_xlim())  
     ### COUNT ARRAY FIGURE # # # # #  #
@@ -182,7 +182,7 @@ def Scaledlikelihood_KDE(Pr_prior_POS, Likelihood_neg, Likelihood_pos, X_train,X
     # ax1.set_ylim(0,ax2_ylims[1])
     
     ax1.legend(fontsize=18)
-    st.pyplot(fig20)
+    shared_pyplot(fig20)
 
 def Posterior_via_NaiveBayes(Pr_input_POS, X_train, X_test, y_train, y_test, x_sample, x_cur):
     """
@@ -264,7 +264,7 @@ def Posterior_Marginal_plot(post_input, post_uniform,marg,x_cur, x_sample):
     ax2.set_ylabel('Marginal Probability', color='orange',fontsize=20)
       
     # plt.legend(loc=1,fontsize=18) 
-    st.pyplot(fig4)
+    shared_pyplot(fig4)
 
     title = st.text_input('Filename', 'StreamlitImageDefault_{}.png'.format(x_cur))
     st.write('The current filename is', title)

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -65,6 +65,7 @@ RUN groupadd -g "${GID}" python \
 
 # Create shared media directory for multi-replica support
 RUN mkdir -p /shared/media && chown python:python /shared/media
+VOLUME ["/shared/media"]
 
 WORKDIR /app
 ENV PYTHONUNBUFFERED=1 \

--- a/app.py
+++ b/app.py
@@ -190,7 +190,7 @@ axins1.xaxis.set_major_formatter(formatter)
 axins1.xaxis.set_major_formatter('{x:0,.0f}')
 
 #Show the VOI plot
-st.pyplot(firstfig2) #)shared_pyplot(
+shared_pyplot(firstfig2)
 
 if showVperfect:  
     

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,39 @@
+services:
+  main:
+    build:
+      dockerfile: Dockerfile.prod
+    environment:
+      - PYTHONUNBUFFERED=1
+      - SHARED_MEDIA_DIR=/shared/media
+      - SHARED_MEDIA_URL=/media
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import requests; response = requests.get('http://localhost:8501/_stcore/health'); exit(0) if response.status_code == 200 else exit(1)\""]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  nginx:
+    image: wodby/nginx:latest
+    depends_on:
+      main:
+        condition: service_healthy
+    volumes_from:
+      - main:ro
+    ports:
+      - "8080:80"
+    environment:
+      NGINX_BACKEND_HOST: main
+      NGINX_BACKEND_PORT: "8501"
+      NGINX_DJANGO_MEDIA_ROOT: "/shared/media/"
+      NGINX_DJANGO_MEDIA_URL: "/media/"
+      NGINX_VHOST_PRESET: django
+      NGINX_WEBSOCKET_UPGRADE: "on"
+      NGINX_WEBSOCKET_READ_TIMEOUT: "3m"
+      NGINX_WEBSOCKET_SEND_TIMEOUT: "3m"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s

--- a/tests/smoke_test_media.sh
+++ b/tests/smoke_test_media.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Smoke test: verifies shared_pyplot writes to /shared/media and nginx serves it
+set -e
+
+NGINX_URL="http://localhost:8080"
+MAX_WAIT=60
+
+echo "Waiting for nginx to be healthy..."
+elapsed=0
+until curl -sf "$NGINX_URL/" > /dev/null 2>&1; do
+  sleep 2
+  elapsed=$((elapsed + 2))
+  if [ $elapsed -ge $MAX_WAIT ]; then
+    echo "FAIL: nginx not healthy after ${MAX_WAIT}s"
+    exit 1
+  fi
+done
+echo "nginx is up after ${elapsed}s"
+
+# Write a test image to shared media via the main container
+echo "Writing test image to shared media..."
+docker compose -f docker-compose.ci.yml exec -T main python -c "
+import matplotlib.pyplot as plt
+from shared_media import shared_pyplot, MEDIA_DIR
+import os
+import unittest.mock as mock
+
+fig, ax = plt.subplots()
+ax.plot([1,2,3], [4,5,6])
+
+with mock.patch('streamlit.components.v1.html'):
+    shared_pyplot(fig)
+plt.close(fig)
+
+files = os.listdir(MEDIA_DIR)
+assert len(files) >= 1, f'No files in {MEDIA_DIR}'
+print(files[0])
+"
+
+# Get the filename that was written
+MEDIA_FILE=$(docker compose -f docker-compose.ci.yml exec -T main python -c "
+import os
+files = [f for f in os.listdir('/shared/media') if f.endswith('.png')]
+print(files[0])
+")
+MEDIA_FILE=$(echo "$MEDIA_FILE" | tr -d '\r\n')
+
+echo "Testing nginx serves /media/${MEDIA_FILE}..."
+HTTP_CODE=$(curl -sf -o /dev/null -w "%{http_code}" "$NGINX_URL/media/${MEDIA_FILE}")
+
+if [ "$HTTP_CODE" = "200" ]; then
+  echo "PASS: nginx serves /media/${MEDIA_FILE} with HTTP 200"
+else
+  echo "FAIL: nginx returned HTTP ${HTTP_CODE} for /media/${MEDIA_FILE}"
+  exit 1
+fi
+
+# Verify content-type is an image
+CONTENT_TYPE=$(curl -sf -o /dev/null -w "%{content_type}" "$NGINX_URL/media/${MEDIA_FILE}")
+if echo "$CONTENT_TYPE" | grep -q "image"; then
+  echo "PASS: content-type is ${CONTENT_TYPE}"
+else
+  echo "FAIL: unexpected content-type: ${CONTENT_TYPE}"
+  exit 1
+fi
+
+echo ""
+echo "All smoke tests passed."

--- a/tests/test_shared_media.py
+++ b/tests/test_shared_media.py
@@ -1,0 +1,92 @@
+"""Tests for shared_media.py - verifies shared storage plot serving."""
+import os
+import hashlib
+import unittest.mock as mock
+
+import pytest
+import matplotlib.pyplot as plt
+
+import shared_media
+
+
+@pytest.fixture
+def media_dir(tmp_path, monkeypatch):
+    """Patch shared_media module to use a temporary directory."""
+    d = tmp_path / "media"
+    d.mkdir()
+    monkeypatch.setattr(shared_media, "MEDIA_DIR", str(d))
+    monkeypatch.setattr(shared_media, "MEDIA_URL", "/media")
+    return d
+
+
+def test_shared_pyplot_writes_png(media_dir):
+    """shared_pyplot writes a content-hashed PNG to SHARED_MEDIA_DIR."""
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3], [1, 4, 9])
+
+    with mock.patch("streamlit.components.v1.html"):
+        shared_media.shared_pyplot(fig)
+    plt.close(fig)
+
+    files = list(media_dir.iterdir())
+    assert len(files) == 1
+    assert files[0].suffix == ".png"
+    assert files[0].stat().st_size > 0
+
+
+def test_shared_pyplot_uses_content_hash(media_dir):
+    """The filename is a sha256 hash of the image content."""
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3], [1, 4, 9])
+
+    with mock.patch("streamlit.components.v1.html"):
+        shared_media.shared_pyplot(fig)
+    plt.close(fig)
+
+    written_file = list(media_dir.iterdir())[0]
+    content = written_file.read_bytes()
+    expected_name = hashlib.sha256(content).hexdigest()[:16] + ".png"
+    assert written_file.name == expected_name
+
+
+def test_shared_pyplot_emits_correct_url(media_dir):
+    """The HTML img tag references /media/<hash>.png."""
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+
+    with mock.patch("streamlit.components.v1.html") as mock_html:
+        shared_media.shared_pyplot(fig)
+    plt.close(fig)
+
+    call_args = mock_html.call_args[0][0]
+    written_file = list(media_dir.iterdir())[0]
+    expected_url = f"/media/{written_file.name}"
+    assert expected_url in call_args
+    assert '<img src="' in call_args
+
+
+def test_shared_pyplot_idempotent(media_dir):
+    """Calling shared_pyplot with identical figures doesn't create duplicates."""
+    for _ in range(3):
+        fig, ax = plt.subplots()
+        ax.plot([1, 2], [3, 4])
+        with mock.patch("streamlit.components.v1.html"):
+            shared_media.shared_pyplot(fig)
+        plt.close(fig)
+
+    files = list(media_dir.iterdir())
+    assert len(files) == 1
+
+
+def test_fallback_to_st_pyplot_when_unavailable(monkeypatch):
+    """Falls back to st.pyplot when shared storage is unavailable."""
+    monkeypatch.setattr(shared_media, "MEDIA_DIR", "/nonexistent/readonly/path")
+
+    fig, ax = plt.subplots()
+    ax.plot([1, 2], [1, 2])
+
+    with mock.patch("streamlit.pyplot") as mock_st_pyplot:
+        shared_media.shared_pyplot(fig)
+    plt.close(fig)
+
+    mock_st_pyplot.assert_called_once()

--- a/tests/test_shared_media.py
+++ b/tests/test_shared_media.py
@@ -78,9 +78,12 @@ def test_shared_pyplot_idempotent(media_dir):
     assert len(files) == 1
 
 
-def test_fallback_to_st_pyplot_when_unavailable(monkeypatch):
+def test_fallback_to_st_pyplot_when_unavailable(monkeypatch, tmp_path):
     """Falls back to st.pyplot when shared storage is unavailable."""
-    monkeypatch.setattr(shared_media, "MEDIA_DIR", "/nonexistent/readonly/path")
+    # Create a file where the directory should be - makedirs will fail
+    blocker = tmp_path / "not_a_dir"
+    blocker.write_text("block")
+    monkeypatch.setattr(shared_media, "MEDIA_DIR", str(blocker / "subdir"))
 
     fig, ax = plt.subplots()
     ax.plot([1, 2], [1, 2])


### PR DESCRIPTION
## Problem

Plots are not showing on the production site. Browser console shows:
```
GET /media/03569f3....png 404 (Not Found)
```

## Root Cause

PR #25 changed `shared_pyplot` to `st.pyplot`, but the nginx config still has `NGINX_MEDIA_ROOT`/`NGINX_MEDIA_URL` set. This creates a `location /media/` block in nginx that intercepts Streamlit's internal `/media/<hash>.png` URLs and tries to serve them as static files from `/shared/media/` (which is empty since nothing writes there anymore).

## Fix

1. Restore `shared_pyplot()` calls (reverts PR #25 changes)
2. Add `VOLUME [/shared/media]` to Dockerfile.prod for proper volume sharing
3. Add unit tests for `shared_media.py` (write, hash, URL, idempotency, fallback)
4. Add CI smoke test (docker-compose.ci.yml + smoke_test_media.sh) that verifies the full flow: app writes PNG to shared volume, nginx serves it at `/media/`
5. Add GitHub Actions workflow for the smoke test

## How it works

`shared_pyplot(fig)` writes content-hashed PNGs to `/shared/media/` and emits `<img src="/media/<hash>.png">`. Nginx serves these directly from the shared volume. This is correct for multi-replica deployments where all tasks share the same filesystem mount.

## Testing

- `pytest tests/test_shared_media.py` - unit tests pass
- `docker compose -f docker-compose.ci.yml up` + `./tests/smoke_test_media.sh` - smoke test passes
- After merge: redeploy to update the running containers